### PR TITLE
Error tweaks

### DIFF
--- a/Sources/MeowVapor/MeowVaporError.swift
+++ b/Sources/MeowVapor/MeowVaporError.swift
@@ -1,3 +1,3 @@
-enum MeowVaporError: Error {
+public enum MeowVaporError: Error {
     case modelInParameterNotFound
 }

--- a/Sources/MeowVapor/MeowVaporError.swift
+++ b/Sources/MeowVapor/MeowVaporError.swift
@@ -1,3 +1,6 @@
 public enum MeowVaporError: Error {
     case modelInParameterNotFound
+    
+    @available(*, deprecated, message: "Don't switch over this enum without a default case, because we may add more cases in the futrure, and that will break your code")
+    case dontSwitchOverThisEnumWithoutADefaultCaseBecauseWeMayAddMoreCasesInTheFutureAndThatWillBreakYourCode
 }

--- a/Sources/MeowVapor/Parameter.swift
+++ b/Sources/MeowVapor/Parameter.swift
@@ -24,7 +24,13 @@ public extension Model where Self: Parameter, Self.Identifier == ObjectId {
     }
     
     public static func resolveParameter(_ parameter: String, on container: Container) throws -> EventLoopFuture<Self> {
-        let id = try ObjectId(parameter)
+        let id: ObjectId
+        
+        do {
+            id = try ObjectId(parameter)
+        } catch {
+            throw MeowVaporError.modelInParameterNotFound
+        }
         
         // Meow contexts should be created on the private container of a request, because they are not meant
         // to be shared cross-request


### PR DESCRIPTION
This PR:

- Makes the `MeowVaporError` enum public
- Catches ObjectId initialisation errors in `resolveParameter`

### Motivation

This allows for better error handling by apps that use MeowVapor. The error type that BSON throws for invalid ObjectId strings is `private`, so it is hard to distinguish between (for example) network errors and an invalid ObjectId string.