### PR TITLE
Add `request.context()` + some small things

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "5.1.1"),
         .package(url: "https://github.com/OpenKitten/Meow.git", from: "2.0.0"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/core.git", from: "3.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add MeowVapor as a dependency via SPM and run `swift package update`.
 Add Meow to your Vapor services. Be sure to change the MongoDB URI to point to your server.
 
 ```swift
-let meow = try MeowProvider(uri: "mongodb://localhost")
+let meow = try MeowProvider(uri: "mongodb://localhost/MyDatabase")
 try services.register(meow)
 ```
 

--- a/Sources/MeowVapor/AutoQueryableModel.swift
+++ b/Sources/MeowVapor/AutoQueryableModel.swift
@@ -66,10 +66,3 @@ extension Reference: ReflectionDecodable where M.Identifier == ObjectId {
         return try (leftDecoded(), rightDecoded())
     }
 }
-
-extension Set: ReflectionDecodable, AnyReflectionDecodable where Element: ReflectionDecodable {
-    public static func reflectDecoded() throws -> (Set<Element>, Set<Element>) {
-        let elements = try Element.reflectDecoded()
-        return ([elements.0], [elements.1])
-    }
-}

--- a/Sources/MeowVapor/MeowProvider.swift
+++ b/Sources/MeowVapor/MeowProvider.swift
@@ -12,8 +12,13 @@ public final class MeowProvider: Provider {
         return .done(on: container)
     }
     
+    public typealias Configurator = ((Meow.Context) -> Void)
+    
     let lazy: Bool
     let connectionSettings: ConnectionSettings
+    
+    /// A closure that is called for each created context. Allows you to configure the context before usage.
+    public var configure: Configurator?
     
     /// Connects to the MongoDB server or cluster located at the URI
     @available(*, deprecated, message: "A new initializer is introduced which is more explicit and connects lazily to your database. See our raedme for more information.")
@@ -27,9 +32,14 @@ public final class MeowProvider: Provider {
     /// The advantage of using `lazy` is the ability to call `request.make(Meow.Context.self)` and `request.make(Meow.Manager.self)`
     ///
     /// For backwards compatibility and predictability, lazy defaults to `false`
-    public init(uri: String, lazy: Bool = true) throws {
+    ///
+    /// - parameter uri: A MongoDB URI, like "mongodb://localhost/MyDatabase". Consult the MongoKitten documentation more information.
+    /// - parameter lazy: When set to true (the default), this allows you to use `request.context()` by lazily connecting to the database.
+    /// - parameter configure: A closure that is called for each created context. Allows you to configure the context before usage.
+    public init(uri: String, lazy: Bool = true, configure: Configurator? = nil) throws {
         self.connectionSettings = try ConnectionSettings(uri)
         self.lazy = lazy
+        self.configure = configure
     }
     
     public func register(_ services: inout Services) throws {
@@ -49,7 +59,22 @@ public final class MeowProvider: Provider {
             }
             
             services.register { container -> Meow.Context in
-                return try container.make(Meow.Manager.self).makeContext()
+                let managerContainer: Container
+                // The context manager should be on the super container (so every request has its own context but shares a database connection with other requests)
+                if let subContainer = container as? SubContainer {
+                    managerContainer = subContainer.superContainer
+                } else {
+                    managerContainer = container
+                }
+                
+                let manager = try managerContainer.make(Manager.self)
+                let context = manager.makeContext()
+                
+                if let configure = self.configure {
+                    configure(context)
+                }
+                
+                return context
             }
         } else {
             services.register { container in
@@ -69,7 +94,15 @@ public final class MeowProvider: Provider {
             }
             
             let manager = try managerContainer.make(Future<Manager>.self)
-            return manager.map { $0.makeContext() }
+            return manager.map { manager in
+                let context = manager.makeContext()
+                
+                if let configure = self.configure {
+                    configure(context)
+                }
+                
+                return context
+            }
         }
     }
 }
@@ -83,6 +116,8 @@ public extension Request {
     
     /// 🐈 Provides a Meow Context for use during this request
     /// The context is made on the `privateContainer` of the request. This means that each request gets its own Context.
+    ///
+    /// This is only available when lazily connecting to the database.
     public func context() throws -> Meow.Context {
         return try self.privateContainer.make()
     }

--- a/Sources/MeowVapor/MeowProvider.swift
+++ b/Sources/MeowVapor/MeowProvider.swift
@@ -76,7 +76,14 @@ public final class MeowProvider: Provider {
 
 public extension Request {
     /// 🐈 Provides a Meow Context for use during this request
+    @available(*, deprecated, message: "The recommended way of using Meow with Vapor Requests is now to use a lazily connecting database with Request.context(), which does not return a future.")
     public func meow() -> Future<Meow.Context> {
         return Future.flatMap(on: self) { try self.privateContainer.make(Future<Meow.Context>.self) }
+    }
+    
+    /// 🐈 Provides a Meow Context for use during this request
+    /// The context is made on the `privateContainer` of the request. This means that each request gets its own Context.
+    public func context() throws -> Meow.Context {
+        return try self.privateContainer.make()
     }
 }


### PR DESCRIPTION
This PR:

- deprecates `request.meow()` in favor of a new (synchronous) `request.context()`
- adds support for a `configure` closure on `MeowProvider`. By setting it, we allow users to perform configuration on the made `Context`
- fixes an issue that was introduced in #4, that caused the `Manager` to be created on `SubContainer`s
- updates the readme to include a database name in the MongoDB URI – the example does not really work without it
- removes `Set: ReflectionDecodable` and adds a dependency of Vapor Core 3.5.0. Since that version, the conformance is implemented in Vapor Core, and causes a compiler warning in MeowVapor